### PR TITLE
Added ordering to the search results

### DIFF
--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -45,17 +45,20 @@ class SearchController extends Controller
         $lowestLevel = "state";
 
         $stateRules = StateMerge::with(['state', 'source', 'destination', 'allowed', 'codesObj', 'incentivesObj', 'permitObj', 'moreInfoObj'])
-                                        ->where("stateID", $request->state_id)->where("location_type", $request->searchType)->get();
+                                        ->where("stateID", $request->state_id)->where("location_type", $request->searchType)
+                                        ->orderBy('sourceID', 'DESC')->orderBy('destinationID', 'DESC')->get();
         if(isset($request->county_id)){
             $countyRules = CountyMerge::with(['county', 'source', 'destination', 'allowed', 'codesObj', 'incentivesObj', 'permitObj', 'moreInfoObj'])
-                ->where("countyID", $request->county_id)->where("location_type", $request->searchType)->get();
+                ->where("countyID", $request->county_id)->where("location_type", $request->searchType)
+                ->orderBy('sourceID', 'DESC')->orderBy('destinationID', 'DESC')->get();
             $lowestLevel = "county";
             $county = County::find($request->county_id);
         }
 
         if(isset($request->city_id)) {
             $cityRules = CityMerge::with(['city', 'source', 'destination', 'allowed', 'codesObj', 'incentivesObj', 'permitObj', 'moreInfoObj'])
-                ->where("cityID", $request->city_id)->where("location_type", $request->searchType)->get();
+                ->where("cityID", $request->city_id)->where("location_type", $request->searchType)
+                ->orderBy('sourceID', 'DESC')->orderBy('destinationID', 'DESC')->get();
             $lowestLevel = "city";
             $city = City::find($request->city_id);
         }


### PR DESCRIPTION
I deleted duplicate (the SQL queries are in the appropriate card in Trello), but I also discovered that the search results were not in a useful order, so I added ordering by source -> destination.